### PR TITLE
Fix mistake in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ end
 The `NDifferentiable` interface can be used as shown below to create various objectives:
 ```julia
 x = zeros(4)
-F = zeros(4)
+F = zeros(2)
 nd   = NonDifferentiable(f!, x, F)
 od   = OnceDifferentiable(f!, j!, x, F)
 odfj = OnceDifferentiable(f!, j!, fj! x, F)


### PR DESCRIPTION
If I'm understanding this correctly, when creating multivalued objective, `F` must be passed, which has the same length of `f!()` output. So in the example it should be `F = zeros(2)`.