### PR TITLE
Use F-dimensions not x-dimensions in autodiff

### DIFF
--- a/src/objective_types/oncedifferentiable.jl
+++ b/src/objective_types/oncedifferentiable.jl
@@ -88,7 +88,7 @@ function OnceDifferentiable(f, x::AbstractArray, F::AbstractArray, DF::AbstractA
         return OnceDifferentiable(fF, dfF, fdfF, x, F, DF)
     else
         if autodiff == :central || autodiff == :finite
-            central_cache = DiffEqDiffTools.JacobianCache(similar(x), similar(x), similar(x))
+            central_cache = DiffEqDiffTools.JacobianCache(similar(x), similar(F), similar(x))
             function fj!(F, J, x)
                 f(F, x)
                 DiffEqDiffTools.finite_difference_jacobian!(J, f, x, central_cache)
@@ -100,7 +100,7 @@ function OnceDifferentiable(f, x::AbstractArray, F::AbstractArray, DF::AbstractA
             end
             return OnceDifferentiable(f, j!, fj!, x, x, DF)
         elseif autodiff == :forward || autodiff == true
-            jac_cfg = ForwardDiff.JacobianConfig(f, x, x, chunk)
+            jac_cfg = ForwardDiff.JacobianConfig(f, F, x, chunk)
             ForwardDiff.checktag(jac_cfg, f, x)
 
             F2 = copy(x)

--- a/src/objective_types/oncedifferentiable.jl
+++ b/src/objective_types/oncedifferentiable.jl
@@ -88,7 +88,7 @@ function OnceDifferentiable(f, x::AbstractArray, F::AbstractArray, DF::AbstractA
         return OnceDifferentiable(fF, dfF, fdfF, x, F, DF)
     else
         if autodiff == :central || autodiff == :finite
-            central_cache = DiffEqDiffTools.JacobianCache(similar(x), similar(F), similar(x))
+            central_cache = DiffEqDiffTools.JacobianCache(similar(x), similar(F), similar(F))
             function fj!(F, J, x)
                 f(F, x)
                 DiffEqDiffTools.finite_difference_jacobian!(J, f, x, central_cache)

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -175,3 +175,16 @@ end
     end
     @test gradient(odad1) ≈ 2 .* a .* (x_seed .+ 1.0)
 end
+
+@testset "jacobian of residual function" begin
+    function f!(F, x)
+        F[1] = (x[1]^3 - 7.0 * x[1]^2 + 14.0 * x[1] - 8)* x[2]^2 * exp(-x[2])
+        F[2] = 2.0 * (1.0 - 8.0 * x[1] + 7.0 * x[1]^2 - (7.0 / 3.0) * x[1]^3 + (1.0 / 4.0) * x[1]^4) * x[2] * exp(-x[2]) - (1.0 - 8.0 * x[1] + 7.0 * x[1]^2 - (7.0 / 3.0) * x[1]^3 + (1.0 / 4.0) * x[1]^4) * x[2]^2 * exp(-x[2])
+    end
+
+    x = zeros(4)
+    F = zeros(2)
+    od = OnceDifferentiable(f!, x, F)
+    # This failed before, now it runs!
+    value_jacobian!!(od, [0., 8., 1., 1.])
+end


### PR DESCRIPTION
Hopefully this will fix LsqFit-problems (notice there are other places where `x` is used where `F` should probably be used).