### PR TITLE
Add `value(d, x)` for multivalued objective

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -162,9 +162,19 @@ function jacobian(obj::AbstractObjective, x)
     obj.DF
 end
 
+value(obj::NonDifferentiable{TF, TX}, x) where {TF<:AbstractArray, TX} = value(obj, copy(obj.F), x)
+value(obj::OnceDifferentiable{TF, TDF, TX}, x) where {TF<:AbstractArray, TDF, TX} = value(obj, copy(obj.F), x)
+function value(obj::AbstractObjective, F, x)
+    if x != obj.x_f
+        obj.f_calls .+= 1
+        return obj.f(F, x)
+    end
+    value(obj)
+end
+
 value!!(obj::NonDifferentiable{TF, TX}, x) where {TF<:AbstractArray, TX} = value!!(obj, obj.F, x)
 value!!(obj::OnceDifferentiable{TF, TDF, TX}, x) where {TF<:AbstractArray, TDF, TX} = value!!(obj, obj.F, x)
-function value!!(obj, F, x)
+function value!!(obj::AbstractObjective, F, x)
     obj.f(F, x)
     copyto!(obj.x_f, x)
     obj.f_calls .+= 1

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -223,12 +223,13 @@
         # calculated by the value(obj, x) methods
         @test value(nd) == value(od) == F_x_seed
         @test value(nd, x_seed) == value(od, x_seed)
+        @test value(nd, x_alt) == value(od, x_alt)
 
         # Test that the Jacobians match the intended values
         @test jacobian(od) == J_x_seed
 
         # Test that the call counters got incremented
-        @test nd.f_calls == od.f_calls == [1]
+        @test nd.f_calls == od.f_calls == [2]
         @test od.df_calls == [1]
 
         # Test that the call counters do not get incremented
@@ -236,14 +237,14 @@
         value!(nd, x_seed)
         value_jacobian!(od, x_seed)
 
-        @test nd.f_calls == od.f_calls == [1]
+        @test nd.f_calls == od.f_calls == [2]
         @test od.df_calls == [1]
 
         # ... and that they do with double-"bang" methods
         value!!(nd, x_seed)
         value_jacobian!!(od, x_seed)
 
-        @test nd.f_calls == od.f_calls == [2]
+        @test nd.f_calls == od.f_calls == [3]
         @test od.df_calls == [2]
 
         # Test that jacobian doesn't work for NonDifferentiable, but does otherwise
@@ -252,19 +253,19 @@
 
         @test value(nd) == value(od) == F_x_seed
         @test jacobian(od) == J_x_alt
-        @test nd.f_calls == od.f_calls == [2]
+        @test nd.f_calls == od.f_calls == [3]
         @test od.df_calls == [3]
 
         @test value(nd) == value(od) == F_x_seed
         @test jacobian(od) == J_x_alt
-        @test nd.f_calls == od.f_calls == [2]
+        @test nd.f_calls == od.f_calls == [3]
         @test od.df_calls == [3]
 
         value!(nd, x_alt)
         value!(od, x_alt)
         @test value(nd) == value(od) == F_x_alt
         @test jacobian(od) == J_x_alt
-        @test nd.f_calls == od.f_calls == [3]
+        @test nd.f_calls == od.f_calls == [4]
         @test od.df_calls == [3]
 
         @test_throws ErrorException value_jacobian!(nd, x_seed)
@@ -281,7 +282,7 @@
         value_jacobian!(od, x_seed)
         @test value(od) == F_x_seed
         @test jacobian(od) == J_x_seed
-        @test od.f_calls == [4]
+        @test od.f_calls == [5]
         @test od.df_calls == [4]
 
         clear!(nd)


### PR DESCRIPTION
This PR add `value(d, x)` method for multivalued objective.