### PR TITLE
Fix the !inplace case for NonDifferentiable

### DIFF
--- a/src/objective_types/nondifferentiable.jl
+++ b/src/objective_types/nondifferentiable.jl
@@ -11,7 +11,7 @@ function NonDifferentiable(f, x::AbstractArray, F::Real = real(zero(eltype(x)));
     NonDifferentiable{typeof(F),typeof(x)}(f, F, x_of_nans(x), [0,])
 end
 function NonDifferentiable(f, x::AbstractArray, F::AbstractArray; inplace = true)
-    f = !inplace && (F isa AbstractArray) ? f!_from_f(f, x, F) : f
+    f = !inplace && (F isa AbstractArray) ? f!_from_f(f, F, inplace) : f
     NonDifferentiable{typeof(F),typeof(x)}(f, F, x_of_nans(x), [0,])
 end
 


### PR DESCRIPTION
This was just leftover syntax from before #72.
I have stumbled upon this issue in my own code (from `nlsolve` called with `method=:anderson`). I have fixed it in the obvious way and it works.
However, I have not added tests since I'm not familiar enough with the internals, and the kwargs.jl test file doesn't have anything about `NonDifferentiable` types so I wouldn't know how to start from scratch.
I think that since the fix is obvious enough this may be merged as is and then tests be added afterwards by someone more knowledgeable than me.