### PR TITLE
Support hv_product! for TwiceDifferentiable

### DIFF
--- a/src/objective_types/twicedifferentiable.jl
+++ b/src/objective_types/twicedifferentiable.jl
@@ -79,7 +79,7 @@ TwiceDifferentiable(d::NonDifferentiable, x_seed::AbstractVector{T} = d.x_f, F::
 function TwiceDifferentiable(d::OnceDifferentiable, x_seed::AbstractVector{T} = d.x_f,
                              F::Real = real(zero(T)); autodiff = :finite) where T<:Real
     if is_finitediff(autodiff)
-        
+
         # Figure out which Val-type to use for DiffEqDiffTools based on our
         # symbol interface.
         fdtype = diffeqdiff_fdtype(autodiff)
@@ -138,4 +138,9 @@ function TwiceDifferentiable(f, x::AbstractVector, F::Real = real(zero(eltype(x)
         error("The autodiff value $(autodiff) is not supported. Use :finite or :forward.")
     end
     TwiceDifferentiable(f, g!, fg!, h!, x, F)
+end
+
+function hv_product!(obj::TwiceDifferentiable, x, v)
+    H = hessian!(obj, x)
+    return H*v
 end

--- a/src/objective_types/twicedifferentiablehv.jl
+++ b/src/objective_types/twicedifferentiablehv.jl
@@ -34,16 +34,18 @@ function gradient!!(obj::TwiceDifferentiableHV, x)
     obj.fdf(obj.DF, x)
 end
 
-function hv_product!(obj::AbstractObjective, x, v)
+function hv_product!(obj::TwiceDifferentiableHV, x, v)
     if x != obj.x_hv ||  v != obj.v_hv
         hv_product!!(obj, x, v)
     end
     obj.Hv
 end
-function hv_product!!(obj::AbstractObjective, x, v)
+function hv_product!!(obj::TwiceDifferentiableHV, x, v)
     obj.hv_calls .+= 1
     copyto!(obj.x_hv, x)
     copyto!(obj.v_hv, v)
     obj.hv(obj.Hv, x, v)
 end
-hv_product(obj) = obj.Hv
+# Deprecate the following?
+# Using it makes code non-generic (it requires storage for the result)
+hv_product(obj::TwiceDifferentiableHV) = obj.Hv

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -32,6 +32,9 @@
         @test gradient(od) == gradient(td) == g_x_seed
         # Test that the Hessian matches the intended value
         @test hessian(td) == h_x_seed
+        # Test hv_product! for TwiceDifferentiable
+        v = [0.111, -1234]
+        @test hv_product!(td, x_seed, v) == h_x_seed * v
 
         # Test that the call counters got incremented
         @test nd.f_calls == od.f_calls == td.f_calls == [2]


### PR DESCRIPTION
The motivation was to be able to use `Optim.KrylovTrustRegion` on CUTEst models. (There will be a separate Optim PR after this gets tagged in a new release.)