### PR TITLE
Allocate df with similar, partially fixes GPU support

### DIFF
--- a/src/objective_types/abstract.jl
+++ b/src/objective_types/abstract.jl
@@ -16,7 +16,12 @@ function make_fdf(x, F::Number, f, g!)
 end
 
 # Initialize an n-by-n Jacobian
-alloc_DF(x, F) = fill(eltype(F)(NaN), length(F), length(x))
+function alloc_DF(x, F)
+  a = (Base.OneTo(length(F)), Base.OneTo(length(x)))
+  df = similar(F, a)
+  fill!(df, NaN)
+  return df
+end
 # Initialize a gradient shaped like x
 alloc_DF(x, F::T) where T<:Number = x_of_nans(x, promote_type(eltype(x), T))
 # Initialize an n-by-n Hessian


### PR DESCRIPTION
This PR allocates `df` using `similar` instead of `eltype` to support `CuArrays`.

Partially fixes [NLsolve.jl's 234](https://github.com/JuliaNLSolvers/NLsolve.jl/issues/234).

Script: `test/runtests_gpu.jl`

```julia
using NLsolve
using LinearAlgebra
using CuArrays
# CuArrays.allowscalar(false)  # toggling this

function f!(F, x)
    mul!(F,A,x)
    F .-= R
end

A = cu(rand(2,2))
R = cu(rand(2))
x = cu([ 0.1; 1.2])
nlsolve(f!, x)
```

Before (without `CuArrays.allowscalar(false)`):

```julia
julia> include("test\\runtests_gpu.jl")
┌ Warning: Performing scalar operations on GPU arrays: This is very slow, consider disallowing these operations with `allowscalar(false)`
└ @ GPUArrays C:\Users\kawcz\.julia\packages\GPUArrays\JqOUg\src\host\indexing.jl:43
ERROR: LoadError: ArgumentError: cannot take the CPU address of a CuArray{Float32,1,Nothing}
Stacktrace:
 [1] dogleg!(::CuArray{Float32,1,Nothing}, ::CuArray{Float32,1,Nothing}, ::CuArray{Float32,1,Nothing}, ::CuArray{Float32,1,Nothing}, ::CuArray{Float32,1,Nothing}, ::Array{Float32,2}, ::Float32) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\solvers\trust_region.jl:61
 [2] trust_region_(::OnceDifferentiable{CuArray{Float32,1,Nothing},Array{Float32,2},CuArray{Float32,1,Nothing}}, ::CuArray{Float32,1,Nothing}, ::Float32, ::Float32, ::Int64, ::Bool, ::Bool, ::Bool, ::Float32, ::Bool, ::NLsolve.NewtonTrustRegionCache{CuArray{Float32,1,Nothing}}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\solvers\trust_region.jl:167
 [3] trust_region at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\solvers\trust_region.jl:229 [inlined] (repeats 2 times)
 [4] #nlsolve#25(::Symbol, ::Float32, ::Float32, ::Int64, ::Bool, ::Bool, ::Bool, ::Static, ::NLsolve.var"#27#29", ::Float32, ::Bool, ::Int64, ::Int64, ::Int64, ::Float32, ::typeof(nlsolve), ::OnceDifferentiable{CuArray{Float32,1,Nothing},Array{Float32,2},CuArray{Float32,1,Nothing}}, ::CuArray{Float32,1,Nothing}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\nlsolve\nlsolve.jl:26
 [5] #nlsolve at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\nlsolve\nlsolve.jl:0 [inlined]
 [6] #nlsolve#30(::Symbol, ::Symbol, ::Bool, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(nlsolve), ::Function, ::CuArray{Float32,1,Nothing}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\nlsolve\nlsolve.jl:52
 [7] nlsolve(::Function, ::CuArray{Float32,1,Nothing}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\nlsolve\nlsolve.jl:46
 [8] top-level scope at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\test\runtests_gpu.jl:14
 [9] include at .\boot.jl:328 [inlined]
 [10] include_relative(::Module, ::String) at .\loading.jl:1105
 [11] include(::Module, ::String) at .\Base.jl:31
 [12] include(::String) at .\client.jl:424
 [13] top-level scope at REPL[1]:1
in expression starting at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\test\runtests_gpu.jl:14
caused by [exception 1]
ArgumentError: cannot take the CPU address of a CuArray{Float32,1,Nothing}
Stacktrace:
 [1] unsafe_convert(::Type{Ptr{Float32}}, ::CuArray{Float32,1,Nothing}) at C:\Users\kawcz\.julia\packages\CuArrays\l0gXB\src\array.jl:226
 [2] getrs!(::Char, ::Array{Float32,2}, ::Array{Int64,1}, ::CuArray{Float32,1,Nothing}) at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.3\LinearAlgebra\src\lapack.jl:1017
 [3] ldiv!(::LU{Float32,Array{Float32,2}}, ::CuArray{Float32,1,Nothing}) at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.3\LinearAlgebra\src\lu.jl:391
 [4] \(::LU{Float32,Array{Float32,2}}, ::CuArray{Float32,1,Nothing}) at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.3\LinearAlgebra\src\factorization.jl:99
 [5] \(::Array{Float32,2}, ::CuArray{Float32,1,Nothing}) at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.3\LinearAlgebra\src\generic.jl:1050
 [6] dogleg!(::CuArray{Float32,1,Nothing}, ::CuArray{Float32,1,Nothing}, ::CuArray{Float32,1,Nothing}, ::CuArray{Float32,1,Nothing}, ::CuArray{Float32,1,Nothing}, ::Array{Float32,2}, ::Float32) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\solvers\trust_region.jl:51
 [7] trust_region_(::OnceDifferentiable{CuArray{Float32,1,Nothing},Array{Float32,2},CuArray{Float32,1,Nothing}}, ::CuArray{Float32,1,Nothing}, ::Float32, ::Float32, ::Int64, ::Bool, ::Bool, ::Bool, ::Float32, ::Bool, ::NLsolve.NewtonTrustRegionCache{CuArray{Float32,1,Nothing}}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\solvers\trust_region.jl:167
 [8] trust_region at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\solvers\trust_region.jl:229 [inlined] (repeats 2 times)
 [9] #nlsolve#25(::Symbol, ::Float32, ::Float32, ::Int64, ::Bool, ::Bool, ::Bool, ::Static, ::NLsolve.var"#27#29", ::Float32, ::Bool, ::Int64, ::Int64, ::Int64, ::Float32, ::typeof(nlsolve), ::OnceDifferentiable{CuArray{Float32,1,Nothing},Array{Float32,2},CuArray{Float32,1,Nothing}}, ::CuArray{Float32,1,Nothing}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\nlsolve\nlsolve.jl:26
 [10] #nlsolve at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\nlsolve\nlsolve.jl:0 [inlined]
 [11] #nlsolve#30(::Symbol, ::Symbol, ::Bool, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(nlsolve), ::Function, ::CuArray{Float32,1,Nothing}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\nlsolve\nlsolve.jl:52
 [12] nlsolve(::Function, ::CuArray{Float32,1,Nothing}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\nlsolve\nlsolve.jl:46
 [13] top-level scope at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\test\runtests_gpu.jl:14
 [14] include at .\boot.jl:328 [inlined]
 [15] include_relative(::Module, ::String) at .\loading.jl:1105
 [16] include(::Module, ::String) at .\Base.jl:31
 [17] include(::String) at .\client.jl:424
 [18] top-level scope at REPL[1]:1
```

After (without `CuArrays.allowscalar(false)`):

```julia
julia> include("test\\runtests_gpu.jl")
[ Info: Precompiling NLsolve [2774e3e8-f4cf-5e23-947b-6d7e65073b56]
┌ Warning: Performing scalar operations on GPU arrays: This is very slow, consider disallowing these operations with `allowscalar(false)`
└ @ GPUArrays C:\Users\kawcz\.julia\packages\GPUArrays\JqOUg\src\host\indexing.jl:43
Results of Nonlinear Solver Algorithm
 * Algorithm: Trust-region with dogleg and autoscaling
 * Starting Point: Float32[0.1, 1.2]
 * Zero: Float32[1.8909574, -1.4453843]
 * Inf-norm of residuals: 0.000000
 * Iterations: 1000
 * Convergence: false
   * |x - x'| < 0.0e+00: false
   * |f(x)| < 1.0e-08: false
 * Function Calls (f): 6
 * Jacobian Calls (df/dx): 4
```

Before (with `CuArrays.allowscalar(false)`):

```julia
julia> include("test\\runtests_gpu.jl")
ERROR: LoadError: scalar getindex is disallowed
Stacktrace:
 [1] error(::String) at .\error.jl:33
 [2] assertscalar(::String) at C:\Users\kawcz\.julia\packages\GPUArrays\JqOUg\src\host\indexing.jl:41
 [3] getindex(::CuArray{Float32,1,Nothing}, ::Int64) at C:\Users\kawcz\.julia\packages\GPUArrays\JqOUg\src\host\indexing.jl:96
 [4] _broadcast_getindex at .\broadcast.jl:596 [inlined]
 [5] _getindex at .\broadcast.jl:626 [inlined]
 [6] _broadcast_getindex at .\broadcast.jl:602 [inlined]
 [7] _getindex at .\broadcast.jl:626 [inlined]
 [8] _broadcast_getindex at .\broadcast.jl:602 [inlined]
 [9] getindex at .\broadcast.jl:563 [inlined]
 [10] macro expansion at .\broadcast.jl:909 [inlined]
 [11] macro expansion at .\simdloop.jl:77 [inlined]
 [12] copyto! at .\broadcast.jl:908 [inlined]
 [13] copyto! at .\broadcast.jl:863 [inlined]
 [14] materialize! at .\broadcast.jl:822 [inlined]
 [15] #finite_difference_jacobian!#40(::Float32, ::Float32, ::UnitRange{Int64}, ::Nothing, ::Bool, ::typeof(FiniteDiff.finite_difference_jacobian!), ::Array{Float32,2}, ::typeof(f!), ::CuArray{Float32,1,Nothing}, ::FiniteDiff.JacobianCache{CuArray{Float32,1,Nothing},CuArray{Float32,1,Nothing},CuArray{Float32,1,Nothing},UnitRange{Int64},Nothing,Val{:central},Float32}, ::Nothing) at C:\Users\kawcz\.julia\packages\FiniteDiff\hcMgi\src\jacobians.jl:371
 [16] finite_difference_jacobian! at C:\Users\kawcz\.julia\packages\FiniteDiff\hcMgi\src\jacobians.jl:295 [inlined] (repeats 2 times)
 [17] (::NLSolversBase.var"#fj_finitediff!#21"{typeof(f!),FiniteDiff.JacobianCache{CuArray{Float32,1,Nothing},CuArray{Float32,1,Nothing},CuArray{Float32,1,Nothing},UnitRange{Int64},Nothing,Val{:central},Float32}})(::CuArray{Float32,1,Nothing}, ::Array{Float32,2}, ::CuArray{Float32,1,Nothing}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLSolversBase.jl\src\objective_types\oncedifferentiable.jl:139
 [18] value_jacobian!!(::OnceDifferentiable{CuArray{Float32,1,Nothing},Array{Float32,2},CuArray{Float32,1,Nothing}}, ::CuArray{Float32,1,Nothing}, ::Array{Float32,2}, ::CuArray{Float32,1,Nothing}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLSolversBase.jl\src\interface.jl:124
 [19] value_jacobian!! at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLSolversBase.jl\src\interface.jl:122 [inlined]
 [20] trust_region_(::OnceDifferentiable{CuArray{Float32,1,Nothing},Array{Float32,2},CuArray{Float32,1,Nothing}}, ::CuArray{Float32,1,Nothing}, ::Float32, ::Float32, ::Int64, ::Bool, ::Bool, ::Bool, ::Float32, ::Bool, ::NLsolve.NewtonTrustRegionCache{CuArray{Float32,1,Nothing}}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\solvers\trust_region.jl:119
 [21] trust_region at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\solvers\trust_region.jl:229 [inlined] (repeats 2 times)
 [22] #nlsolve#25(::Symbol, ::Float32, ::Float32, ::Int64, ::Bool, ::Bool, ::Bool, ::Static, ::NLsolve.var"#27#29", ::Float32, ::Bool, ::Int64, ::Int64, ::Int64, ::Float32, ::typeof(nlsolve), ::OnceDifferentiable{CuArray{Float32,1,Nothing},Array{Float32,2},CuArray{Float32,1,Nothing}}, ::CuArray{Float32,1,Nothing}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\nlsolve\nlsolve.jl:26
 [23] #nlsolve at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\nlsolve\nlsolve.jl:0 [inlined]
 [24] #nlsolve#30(::Symbol, ::Symbol, ::Bool, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(nlsolve), ::Function, ::CuArray{Float32,1,Nothing}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\nlsolve\nlsolve.jl:52
 [25] nlsolve(::Function, ::CuArray{Float32,1,Nothing}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\nlsolve\nlsolve.jl:46
 [26] top-level scope at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\test\runtests_gpu.jl:14
 [27] include at .\boot.jl:328 [inlined]
 [28] include_relative(::Module, ::String) at .\loading.jl:1105
 [29] include(::Module, ::String) at .\Base.jl:31
 [30] include(::String) at .\client.jl:424
 [31] top-level scope at REPL[1]:1
in expression starting at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\test\runtests_gpu.jl:14
```

After (with `CuArrays.allowscalar(false)`):

```julia
julia> include("test\\runtests_gpu.jl")
ERROR: LoadError: scalar setindex! is disallowed
Stacktrace:
 [1] error(::String) at .\error.jl:33
 [2] assertscalar(::String) at C:\Users\kawcz\.julia\packages\GPUArrays\JqOUg\src\host\indexing.jl:41
 [3] setindex!(::CuArray{Float32,1,Nothing}, ::Float32, ::Int64) at C:\Users\kawcz\.julia\packages\GPUArrays\JqOUg\src\host\indexing.jl:103
 [4] trust_region_(::OnceDifferentiable{CuArray{Float32,1,Nothing},CuArray{Float32,2,Nothing},CuArray{Float32,1,Nothing}}, ::CuArray{Float32,1,Nothing}, ::Float32, ::Float32, ::Int64, ::Bool, ::Bool, ::Bool, ::Float32, ::Bool, ::NLsolve.NewtonTrustRegionCache{CuArray{Float32,1,Nothing}}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\solvers\trust_region.jl:147
 [5] trust_region at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\solvers\trust_region.jl:229 [inlined] (repeats 2 times)
 [6] #nlsolve#25(::Symbol, ::Float32, ::Float32, ::Int64, ::Bool, ::Bool, ::Bool, ::Static, ::NLsolve.var"#27#29", ::Float32, ::Bool, ::Int64, ::Int64, ::Int64, ::Float32, ::typeof(nlsolve), ::OnceDifferentiable{CuArray{Float32,1,Nothing},CuArray{Float32,2,Nothing},CuArray{Float32,1,Nothing}}, ::CuArray{Float32,1,Nothing}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\nlsolve\nlsolve.jl:26
 [7] #nlsolve at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\nlsolve\nlsolve.jl:0 [inlined]
 [8] #nlsolve#30(::Symbol, ::Symbol, ::Bool, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(nlsolve), ::Function, ::CuArray{Float32,1,Nothing}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\nlsolve\nlsolve.jl:52
 [9] nlsolve(::Function, ::CuArray{Float32,1,Nothing}) at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\src\nlsolve\nlsolve.jl:46
 [10] top-level scope at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\test\runtests_gpu.jl:14
 [11] include at .\boot.jl:328 [inlined]
 [12] include_relative(::Module, ::String) at .\loading.jl:1105
 [13] include(::Module, ::String) at .\Base.jl:31
 [14] include(::String) at .\client.jl:424
 [15] top-level scope at REPL[1]:1
in expression starting at C:\Users\kawcz\Dropbox\Caltech\work\dev\clones\NLsolve.jl\test\runtests_gpu.jl:14
```
