### PR TITLE
make x_of_nans work on 0-dimensional arrays

### DIFF
--- a/src/NLSolversBase.jl
+++ b/src/NLSolversBase.jl
@@ -57,7 +57,7 @@ end
 is_finitediff(autodiff) = autodiff ∈ (:central, :finite, :finiteforward, :finitecomplex)
 is_forwarddiff(autodiff) = autodiff ∈ (:forward, :forwarddiff, true)
 
-x_of_nans(x, Tf=eltype(x)) = fill!(Tf.(x), Tf(NaN))
+x_of_nans(x, Tf=eltype(x)) = fill!(map(Tf,x), Tf(NaN))
 
 include("objective_types/inplace_factory.jl")
 include("objective_types/abstract.jl")


### PR DESCRIPTION
The `x_of_nans` function gives a `MethodError` for 0-dimensional arrays due to JuliaLang/julia#41643.   A workaround is to use `map(Tf, x)` instead of `Tf.(x)`.

Before this PR:
```jl
julia> x_of_nans(fill(0.0))
ERROR: MethodError: no method matching fill!(::Float64, ::Float64)
...
```
After this PR:
```
julia> x_of_nans(fill(0.0))
0-dimensional Array{Float64, 0}:
NaN
```