### PR TITLE
remove unused type variable

### DIFF
--- a/src/objective_types/incomplete.jl
+++ b/src/objective_types/incomplete.jl
@@ -93,7 +93,7 @@ end
 const InPlaceFGH = InplaceObjective{<:Nothing,<:Nothing,TH,<:Nothing,<:Nothing} where {TH}
 const InPlaceFG_HV = InplaceObjective{<:Nothing,TFG,<:Nothing,THv,<:Nothing} where {TFG,THv}
 const InPlaceFGHV = InplaceObjective{<:Nothing,<:Nothing,<:Nothing,<:Nothing,TFGHv} where {TFGHv}
-function TwiceDifferentiable(t::InPlaceFGH, x::AbstractArray, F::Real = real(zero(eltype(x))), G::AbstractArray = alloc_DF(x, F), H = alloc_H(x, F)) where {TH}
+function TwiceDifferentiable(t::InPlaceFGH, x::AbstractArray, F::Real = real(zero(eltype(x))), G::AbstractArray = alloc_DF(x, F), H = alloc_H(x, F))
     f   =     x  -> t.fgh(F, nothing, nothing, x)
     df  = (G, x) -> t.fgh(nothing, G, nothing, x)
     fdf = (G, x) -> t.fgh(F, G, nothing, x)


### PR DESCRIPTION
I got a warning on Julia v1.8.2:

```
[ Info: Precompiling OrdinaryDiffEq [1dea7af3-3e70-54e6-95c3-0bf5283fa5ed]
WARNING: method definition for TwiceDifferentiable at ~/.julia/packages/NLSolversBase/cfJrN/src/objective_types/incomplete.jl:96 declares type variable TH but does not use it.
```

Unused type variables can sometimes be bad, see JuliaLang/julia#29393