### PR TITLE
Update CI: Test `min` instead of `pre`

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -2,9 +2,8 @@ name: Run tests
 
 on:
   push:
-    branches:
-      - master
-      - main
+    branches: [master]
+    tags: ["*"]
   pull_request:
 
 # needed to allow julia-actions/cache to delete old caches that it has created
@@ -14,19 +13,27 @@ permissions:
 
 jobs:
   test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        julia-version: ['lts', '1', 'pre']
+        version:
+          - 'min'
+          - 'lts'
+          - '1'
         os: [ubuntu-latest, windows-latest, macOS-latest]
-
+        exclude:
+          - os: macOS-latest # Apple Silicon
+            version: 'min'
+        include:
+          - os: macOS-13 # Intel
+            version: 'min'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: ${{ matrix.julia-version }}
+          version: ${{ matrix.version }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-        # with:
-        #   annotate: true


### PR DESCRIPTION
IMO it's much more important to test `min`. I updated the CI job based on the version in SpecialFunctions and other packages.