### PR TITLE
Add `const` annotations to immutable fields

### DIFF
--- a/src/objective_types/nondifferentiable.jl
+++ b/src/objective_types/nondifferentiable.jl
@@ -1,8 +1,8 @@
 # Used for objectives and solvers where no gradient is available/exists
 mutable struct NonDifferentiable{TF<:Union{AbstractArray,Real},TX<:AbstractArray} <: AbstractObjective
-    f
+    const f
     F::TF
-    x_f::TX
+    const x_f::TX
     f_calls::Int
 end
 

--- a/src/objective_types/oncedifferentiable.jl
+++ b/src/objective_types/oncedifferentiable.jl
@@ -1,12 +1,12 @@
 # Used for objectives and solvers where the gradient is available/exists
 mutable struct OnceDifferentiable{TF<:Union{AbstractArray,Real}, TDF<:AbstractArray, TX<:AbstractArray} <: AbstractObjective
-    f # objective
-    df # (partial) derivative of objective
-    fdf # objective and (partial) derivative of objective
+    const f # objective
+    const df # (partial) derivative of objective
+    const fdf # objective and (partial) derivative of objective
     F::TF # cache for f output
-    DF::TDF # cache for df output
-    x_f::TX # x used to evaluate f (stored in F)
-    x_df::TX # x used to evaluate df (stored in DF)
+    const DF::TDF # cache for df output
+    const x_f::TX # x used to evaluate f (stored in F)
+    const x_df::TX # x used to evaluate df (stored in DF)
     f_calls::Int
     df_calls::Int
 end

--- a/src/objective_types/twicedifferentiable.jl
+++ b/src/objective_types/twicedifferentiable.jl
@@ -1,17 +1,17 @@
 # Used for objectives and solvers where the gradient and Hessian is available/exists
 mutable struct TwiceDifferentiable{T<:Real,TDF<:AbstractArray,TH<:AbstractMatrix,TX<:AbstractArray} <: AbstractObjective
-    f
-    df
-    fdf
-    dfh
-    fdfh
-    h
+    const f
+    const df
+    const fdf
+    const dfh
+    const fdfh
+    const h
     F::T
-    DF::TDF
-    H::TH
-    x_f::TX
-    x_df::TX
-    x_h::TX
+    const DF::TDF
+    const H::TH
+    const x_f::TX
+    const x_df::TX
+    const x_h::TX
     f_calls::Int
     df_calls::Int
     h_calls::Int

--- a/src/objective_types/twicedifferentiablehv.jl
+++ b/src/objective_types/twicedifferentiablehv.jl
@@ -1,15 +1,15 @@
 # Used for objectives and solvers where the gradient and Hessian is available/exists
 mutable struct TwiceDifferentiableHV{T,TDF,THv,TX} <: AbstractObjective
-    f
-    fdf
-    hv
+    const f
+    const fdf
+    const hv
     F::T
-    DF::TDF
-    Hv::THv
-    x_f::TX
-    x_df::TX
-    x_hv::TX
-    v_hv::TX
+    const DF::TDF
+    const Hv::THv
+    const x_f::TX
+    const x_df::TX
+    const x_hv::TX
+    const v_hv::TX
     f_calls::Int
     df_calls::Int
     hv_calls::Int


### PR DESCRIPTION
From the Julia docs:

> In cases where one or more fields of an otherwise mutable struct is known to be immutable, one can declare these fields as such using const as shown below. This enables some, but not all of the optimizations of immutable structs, and can be used to enforce invariants on the particular fields marked as const.

https://docs.julialang.org/en/v1/manual/types/#Mutable-Composite-Types