### PR TITLE
Prepare differentiation for the type the caches use

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NLSolversBase"
 uuid = "d41bc354-129a-5804-8e4c-c37616107c6c"
-version = "8.0.0"
+version = "8.0.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/NLSolversBase.jl
+++ b/src/NLSolversBase.jl
@@ -49,6 +49,13 @@ export AbstractConstraints, OnceDifferentiableConstraints,
 
 x_of_nans(x::AbstractArray, ::Type{Tf}=float(eltype(x))) where {Tf} = fill!(similar(x, Tf), NaN)
 
+# Differentiation is prepared once, at construction, and then reused for every evaluation. Preparation has to
+# see the array type the evaluations will use, and that is the type of the x caches, not necessarily the type
+# of the array the caller handed us: the caches come from `similar`, which can change the container (a
+# ReinterpretArray becomes an Array). The caller's values are carried over because preparation evaluates the
+# objective, so a cache full of NaNs is not a safe point to prepare at.
+x_of_values(x::AbstractArray, ::Type{Tf}=float(eltype(x))) where {Tf} = copyto!(x_of_nans(x, Tf), x)
+
 include("objective_types/inplace_factory.jl")
 include("objective_types/abstract.jl")
 include("objective_types/nondifferentiable.jl")

--- a/src/NLSolversBase.jl
+++ b/src/NLSolversBase.jl
@@ -54,7 +54,7 @@ x_of_nans(x::AbstractArray, ::Type{Tf}=float(eltype(x))) where {Tf} = fill!(simi
 # of the array the caller handed us: the caches come from `similar`, which can change the container (a
 # ReinterpretArray becomes an Array). The caller's values are carried over because preparation evaluates the
 # objective, so a cache full of NaNs is not a safe point to prepare at.
-x_of_values(x::AbstractArray, ::Type{Tf}=float(eltype(x))) where {Tf} = copyto!(x_of_nans(x, Tf), x)
+x_of_values(x::AbstractArray) = copyto!(x_of_nans(x), x)
 
 include("objective_types/inplace_factory.jl")
 include("objective_types/abstract.jl")

--- a/src/objective_types/oncedifferentiable.jl
+++ b/src/objective_types/oncedifferentiable.jl
@@ -55,7 +55,7 @@ function OnceDifferentiable(f, x_seed::AbstractArray,
 
         return OnceDifferentiable(fF, dfF, fdfF, jvpF, fjvpF, copy(F), copy(DF), alloc_JVP(x_seed, F), x_f, x_df, x_jvp, v_jvp, 0, 0, 0)
     else
-        grad_prep = DI.prepare_gradient(f, autodiff, x_seed)
+        grad_prep = DI.prepare_gradient(f, autodiff, x_of_values(x_seed))
         g! = let f = f, grad_prep = grad_prep, autodiff = autodiff
             function (_g, _x)
                 DI.gradient!(f, _g, grad_prep, autodiff, _x)
@@ -97,7 +97,7 @@ function OnceDifferentiable(f, x_seed::AbstractArray,
         return OnceDifferentiable(fF, dfF, fdfF, jvpF, fjvpF, copy(F), copy(DF), alloc_JVP(x_seed, F), x_f, x_df, x_jvp, v_jvp, 0, 0, 0)
     else
         F2 = similar(F)
-        jac_prep = DI.prepare_jacobian(f, F2, autodiff, x_seed)
+        jac_prep = DI.prepare_jacobian(f, F2, autodiff, x_of_values(x_seed))
         j! = let f = f, F2 = F2, jac_prep = jac_prep, autodiff = autodiff
             function (_j, _x)
                 DI.jacobian!(f, F2, _j, jac_prep, autodiff, _x)

--- a/src/objective_types/twicedifferentiable.jl
+++ b/src/objective_types/twicedifferentiable.jl
@@ -84,7 +84,9 @@ function TwiceDifferentiable(f, g,
     g! = df!_from_df(g, F, inplace)
     fg! = make_fdf(x_seed, F, f, g!)
 
-    hess_prep = DI.prepare_hessian(f, autodiff, x_seed)
+    x_prep = x_of_values(x_seed)
+
+    hess_prep = DI.prepare_hessian(f, autodiff, x_prep)
     h! = let f = f, hess_prep = hess_prep, autodiff = autodiff
         function (_h, _x)
             DI.hessian!(f, _h, hess_prep, autodiff, _x)
@@ -94,7 +96,7 @@ function TwiceDifferentiable(f, g,
     dfh! = make_dfh(x_seed, F, g!, h!)
     fdfh! = make_fdfh(x_seed, F, fg!, h!)
 
-    hvp_prep = DI.prepare_hvp(f, autodiff, x_seed, (x_seed,))
+    hvp_prep = DI.prepare_hvp(f, autodiff, x_prep, (x_prep,))
     hvp! = let f = f, hv_prep = hvp_prep, autodiff = autodiff
         function (_hvp, _x, _v)
             DI.hvp!(f, (_hvp,), hv_prep, autodiff, _x, (_v,))
@@ -128,7 +130,9 @@ function TwiceDifferentiable(d::OnceDifferentiable,
                              x_seed::AbstractArray = d.x_f,
                              F::Real = real(eltype(x_seed))(NaN);
                              autodiff::AbstractADType = AutoFiniteDiff(; fdtype = Val(:central)))
-    hess_prep = DI.prepare_hessian(d.f, autodiff, x_seed)
+    x_prep = x_of_values(x_seed)
+
+    hess_prep = DI.prepare_hessian(d.f, autodiff, x_prep)
     h! = let f = d.f, hess_prep = hess_prep, autodiff = autodiff
         function (_h, _x)
             DI.hessian!(f, _h, hess_prep, autodiff, _x)
@@ -138,7 +142,7 @@ function TwiceDifferentiable(d::OnceDifferentiable,
     dfh! = make_dfh(x_seed, F, d.df, h!)
     fdfh! = make_fdfh(x_seed, F, d.fdf, h!)
 
-    hvp_prep = DI.prepare_hvp(d.f, autodiff, x_seed, (x_seed,))
+    hvp_prep = DI.prepare_hvp(d.f, autodiff, x_prep, (x_prep,))
     hvp! = let f = d.f, hv_prep = hvp_prep, autodiff = autodiff
         function (_hvp, _x, _v)
             DI.hvp!(f, (_hvp,), hv_prep, autodiff, _x, (_v,))
@@ -164,7 +168,9 @@ end
 function TwiceDifferentiable(f, x::AbstractArray, F::Real = real(eltype(x))(NaN);
                              inplace::Bool = true,
                              autodiff::AbstractADType = AutoFiniteDiff(; fdtype = Val(:central)))
-    grad_prep = DI.prepare_gradient(f, autodiff, x)
+    x_prep = x_of_values(x)
+
+    grad_prep = DI.prepare_gradient(f, autodiff, x_prep)
     g! = let f = f, grad_prep = grad_prep, autodiff = autodiff
         function (_g, _x)
             DI.gradient!(f, _g, grad_prep, autodiff, _x)
@@ -177,7 +183,7 @@ function TwiceDifferentiable(f, x::AbstractArray, F::Real = real(eltype(x))(NaN)
             return y
         end
     end
-    hess_prep = DI.prepare_hessian(f, autodiff, x)
+    hess_prep = DI.prepare_hessian(f, autodiff, x_prep)
     gh! = let f = f, hess_prep = hess_prep, autodiff = autodiff
         function (_g, _h, _x)
             DI.value_gradient_and_hessian!(f, _g, _h, hess_prep, autodiff, _x)
@@ -196,7 +202,7 @@ function TwiceDifferentiable(f, x::AbstractArray, F::Real = real(eltype(x))(NaN)
             return nothing
         end
     end
-    hvp_prep = DI.prepare_hvp(f, autodiff, x, (x,))
+    hvp_prep = DI.prepare_hvp(f, autodiff, x_prep, (x_prep,))
     hvp! = let f = f, hv_prep = hvp_prep, autodiff = autodiff
         function (_hvp, _x, _v)
             DI.hvp!(f, (_hvp,), hv_prep, autodiff, _x, (_v,))

--- a/test/abstractarrays.jl
+++ b/test/abstractarrays.jl
@@ -63,3 +63,32 @@ end
     @test od.x_f isa ArrayPartition
     @test od.x_df isa ArrayPartition
 end
+
+@testset "https://github.com/JuliaNLSolvers/NLSolversBase.jl/issues/172" begin
+    # The x caches come from `similar`, which turns a ReinterpretArray into an Array. Differentiation is
+    # prepared once at construction and reused, so it has to be prepared for the type the evaluations use.
+    @testset for autodiff in (AutoFiniteDiff(; fdtype = Val(:central)), AutoForwardDiff())
+        x_seed = reinterpret(Float64, [2.0 + 3.0im])
+        @test !(x_seed isa Array)
+        @test NLSolversBase.x_of_nans(x_seed) isa Array
+
+        f!(F, x) = (F[1] = x[1]^2 - 2; F[2] = x[2]^2 - 3)
+        od = OnceDifferentiable(f!, x_seed, copy(x_seed), autodiff)
+        @test od.x_f isa Array
+        value_jacobian!!(od, [2.0, 3.0])
+        @test value(od) ≈ [2.0, 6.0]
+        @test jacobian(od) ≈ [4.0 0.0; 0.0 6.0]
+
+        g(x) = sum(abs2, x)
+        od2 = OnceDifferentiable(g, x_seed, 0.0; autodiff = autodiff)
+        value_gradient!!(od2, [2.0, 3.0])
+        @test value(od2) ≈ 13.0
+        @test gradient(od2) ≈ [4.0, 6.0]
+
+        td = TwiceDifferentiable(g, x_seed, 0.0; autodiff = autodiff)
+        value_gradient!!(td, [2.0, 3.0])
+        hessian!!(td, [2.0, 3.0])
+        @test gradient(td) ≈ [4.0, 6.0]
+        @test hessian(td) ≈ [2.0 0.0; 0.0 2.0]
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,6 +93,7 @@ end
     include("incomplete.jl")
     include("constraints.jl")
     include("abstractarrays.jl")
+    include("complex.jl")
     include("autodiff.jl")
     include("sparse.jl")
     include("kwargs.jl")


### PR DESCRIPTION
Fixes #172.

## What was wrong

Differentiation is prepared once, at construction, and then reused for every evaluation. Preparation was seeded with the array the caller passed in, but evaluation uses the `x` caches, and those are built with `similar`, which does not always keep the caller's container: a `ReinterpretArray` comes back as an `Array`.

DI 0.6 defaulted `strict = Val(false)` and let the inconsistency through. DI 0.7 flipped the default, and since the compat range here is `"0.6.43, 0.7"`, an ordinary upgrade turned a silent mismatch into a hard error. Nothing in this package changed.

```julia
x0 = reinterpret(Float64, [1.0+1.0im])
df = OnceDifferentiable(f!, x0, copy(x0), AutoFiniteDiff())
typeof(x0)        # ReinterpretArray{Float64, 1, ComplexF64, Vector{ComplexF64}, false}
typeof(df.x_f)    # Vector{Float64}
value_jacobian!!(df, copy(df.x_f))   # PreparationMismatchError
```

## The fix

Seed preparation from `x_of_values(x_seed)`, a new sibling of `x_of_nans` that returns an array with the cache's type carrying the caller's values.

The values are not incidental. DI evaluates the objective while preparing (`prepare_gradient_nokwarg` runs `y = f(x, ...)`), so preparing at the NaN-filled cache would call the user's function at NaN during construction, which breaks tape-recording backends, local sparsity detection, and any objective with a domain guard.

Nine sites: gradient and jacobian in `OnceDifferentiable`, and hessian, hvp and gradient across the three `TwiceDifferentiable` constructors. The hvp tangent tuple gets it too, since the tangent type is part of the signature DI compares.

## Deliberately not addressed

- The constraint constructors (`constraints.jl:141`, `:176`, `:188`) prepare at a freshly built `zeros(T, n)` and have no cache to refer to, so they are the mirror image of this bug rather than the same one.
- The jacobian `y` slot prepares with `F2 = similar(F)` while `fj!` is handed `obj.F = copy(F)`. Same types for ordinary arrays, latent otherwise.

Both are latent and neither has a reproducer, so they are left for a separate change.

## One behaviour change worth recording

`similar` is the whole mechanism, and it only bites for immutable static arrays:

- an `MArray` seed gives an `MArray` cache, so the preparation point is unchanged and behaviour is identical. This is the static-array path Optim supports.
- an `SArray` seed gives an `MArray` cache (asserted at `test/utils.jl:13`), so preparation moves to `MArray` while a caller would still pass `SArray`. `SArray` plus an autodiff backend would now throw.

Nothing constructs an objective from an `SArray` in the test suite, and Optim's state needs mutable arrays, so this is theoretical rather than live. Flagging it rather than burying it.

## Testing

Full suite green on Julia 1.10 and 1.12: 1632 passing, including Aqua, JET and ExplicitImports.

New regression testset in `test/abstractarrays.jl`, named after this issue and run against both `AutoFiniteDiff(; fdtype = Val(:central))` and `AutoForwardDiff()`, covering the jacobian, gradient and hessian paths. It uses `reinterpret`, so it needs no new test dependency. That file was the right home: it is already the array-container file and already asserts on `x_f`, but all three of its existing testsets supply explicit derivatives, so no exotic container ever reached DI.

`test/complex.jl` existed but was missing from the include list in `runtests.jl`, so it had never run. It is wired in here and passes.

Cross-checked downstream against JuliaNLSolvers/NLsolve.jl#299, which carries six `@test_broken` markers waiting on this. With this branch developed in, all six report `Unexpected Pass`, which is the signal to convert them back to `@test`.

---

This pull request was written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
