### PR TITLE
Fix stale value in value_gradient_hessian! and G/H aliasing in a TwiceDifferentiable constructor

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -321,6 +321,9 @@ function value_gradient_hessian!(obj::TwiceDifferentiable, x)
         elseif x != obj.x_df
             # Only function value and gradient have to be evaluated
             value_gradient!!(obj, x)
+        else
+            # Only function value has to be evaluated
+            value!!(obj, x)
         end
     elseif x != obj.x_df
         if x != obj.x_h

--- a/src/objective_types/twicedifferentiable.jl
+++ b/src/objective_types/twicedifferentiable.jl
@@ -71,7 +71,7 @@ function TwiceDifferentiable(f, g, h,
     x_hvp = x_of_nans(x)
     v_hvp = x_of_nans(x)
 
-    return TwiceDifferentiable(f, g!, fg!, nothing, nothing, dfh!, fdfh!, h!, nothing, F, G, alloc_JVP(x, F), H, copy(G), x_f, x_df, x_jvp, v_jvp, x_h, x_hvp, v_hvp, 0, 0, 0, 0, 0)
+    return TwiceDifferentiable(f, g!, fg!, nothing, nothing, dfh!, fdfh!, h!, nothing, copy(F), copy(G), alloc_JVP(x, F), copy(H), copy(G), x_f, x_df, x_jvp, v_jvp, x_h, x_hvp, v_hvp, 0, 0, 0, 0, 0)
 end
 
 

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -441,3 +441,32 @@ for T in (Float32, Float64, BigFloat)
         end
     end
 end
+
+@testset "value_gradient_hessian! evaluates the value if only gradient and Hessian are cached" begin
+    x = [0.5, 0.3]
+    td = TwiceDifferentiable(exponential, exponential_gradient!, exponential_hessian!, similar(x))
+    gradient_hessian!(td, x)
+    @test isnan(value(td))
+    F, DF, H = value_gradient_hessian!(td, x)
+    @test F ≈ exponential(x)
+    @test value(td) ≈ exponential(x)
+    @test td.x_f == x
+    @test DF == exponential_gradient!(similar(x), x)
+    @test H == exponential_hessian!(fill(0.0, 2, 2), x)
+    @test f_calls(td) == 1
+    @test g_calls(td) == 1
+    @test h_calls(td) == 1
+end
+
+@testset "TwiceDifferentiable(f, g, h, x, F, G, H) does not alias user-provided G and H" begin
+    x = [0.5, 0.3]
+    G = fill(0.0, 2)
+    H = fill(0.0, 2, 2)
+    td = TwiceDifferentiable(exponential, exponential_gradient!, exponential_hessian!, x, 0.0, G, H)
+    @test td.DF !== G
+    @test td.H !== H
+    gradient!(td, x)
+    hessian!(td, x)
+    @test iszero(G)
+    @test iszero(H)
+end


### PR DESCRIPTION
Two fixes:

**`value_gradient_hessian!` returned a stale `F` when only the value was missing from the cache.** The branching had no case for `x == x_h && x == x_df && x != x_f`, so nothing was evaluated and the old `obj.F` was returned. This happens, for example, after calling `gradient_hessian!(obj, x)` on a fresh objective:

```julia
td = TwiceDifferentiable(f, g!, h!, x0)
gradient_hessian!(td, x0)
F, DF, H = value_gradient_hessian!(td, x0)  # F was NaN
```

The fix adds the missing `else` branch, which evaluates the value with `value!!`.

**`TwiceDifferentiable(f, g, h, x, F, G, H)` stored the caller's `G` and `H` without copying**, so `obj.DF === G` and `obj.H === H`. The 4-function compatibility constructor and the released versions copy these arrays. This constructor now copies them too.

Regression tests added for both.

Written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)